### PR TITLE
fix: remove rounding of x-axis location

### DIFF
--- a/packages/series/src/CandlestickSeries.tsx
+++ b/packages/series/src/CandlestickSeries.tsx
@@ -143,7 +143,7 @@ export class CandlestickSeries extends React.Component<CandlestickSeriesProps> {
                 }
 
                 const xValue = xAccessor(d);
-                const x = Math.round(xScale(xValue));
+                const x = xScale(xValue);
                 const y = Math.round(yScale(Math.max(ohlc.open, ohlc.close)));
                 const height = Math.max(1, Math.round(Math.abs(yScale(ohlc.open) - yScale(ohlc.close))));
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

This will perfect the spacing between candles by removing the unnecessary discretization (which was impacting both `react-stockcharts` and `react-financial-charts`).

NOTE: This is #2 of 2 pull requests. This one is focused on CandlestickSeries.tsx.

![postchange](https://user-images.githubusercontent.com/37128022/125335166-3ef79580-e31a-11eb-8fd8-a186e39ba3ab.png)


#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
