### PR TITLE
docs: update links with new organisation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: ci
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: gh-pages
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 > **Note:** v1 is a fully breaking change with large parts, if not all, rewritten. Do not expect the same API! although the same features should exist.
 
-![ci](https://github.com/reactivemarkets/react-financial-charts/workflows/ci/badge.svg)
+![ci](https://github.com/react-financial/react-financial-charts/workflows/ci/badge.svg)
 [![codecov](https://codecov.io/gh/reactivemarkets/react-financial-charts/branch/master/graph/badge.svg)](https://codecov.io/gh/reactivemarkets/react-financial-charts)
- [![GitHub license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/reactivemarkets/react-financial-charts/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/react-financial-charts.svg?style=flat)](https://www.npmjs.com/package/react-financial-charts)
+ [![GitHub license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/react-financial/react-financial-charts/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/react-financial-charts.svg?style=flat)](https://www.npmjs.com/package/react-financial-charts)
 
 Charts dedicated to finance.
 
@@ -61,7 +61,7 @@ npm install react-financial-charts
 
 ## Documentation
 
-[Stories](https://reactivemarkets.github.io/react-financial-charts/)
+[Stories](https://react-financial.github.io/react-financial-charts/)
 
 ## Contributing
 
@@ -72,7 +72,7 @@ This project is a mono-repo that uses [Lerna](https://lernajs.io/) to manage dep
 To get started run:
 
 ```bash
-git clone https://github.com/reactivemarkets/react-financial-charts.git
+git clone https://github.com/react-financial/react-financial-charts.git
 cd react-financial-charts
 npm ci
 npm run build

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,7 @@
       "noGitReset": true
     },
     "version": {
-      "allowBranch": "master",
+      "allowBranch": "main",
       "conventionalCommits": true,
       "createRelease": "github",
       "gitRemote": "upstream",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated

Replaced reactivemarkets with react-financial in most links in the docs
Did not update codecov due to the [badge link](https://codecov.io/gh/react-financial/react-financial-charts/branch/master/graph/badge.svg) and [link to check coverage](https://codecov.io/gh/react-financial/react-financial-charts) being invalid with new org name, not sure why.
Also didn't update fossa status on line 108 because I'm not sure what this is and get 404s when I click on these links with both reactivemarkets and react-financial in the link.
