### PR TITLE
Remove type: module

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -2,7 +2,6 @@
   "name": "react-financial-charts",
   "version": "1.3.2",
   "description": "React charts specific to finance.",
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/coordinates/package.json
+++ b/packages/coordinates/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/indicators/package.json
+++ b/packages/indicators/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/interactive/package.json
+++ b/packages/interactive/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/scales/package.json
+++ b/packages/scales/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/series/package.json
+++ b/packages/series/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "files": [


### PR DESCRIPTION
Author of the package mentioned potentially removing the `type:module` to make this package work again under Webpack 5.

#### Checklist
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
